### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # Makefile for OTP.
 
+prefix = /usr/local
+bindir = $(prefix)/bin
+
 all: check
 
 test: check
@@ -15,10 +18,11 @@ quickcheck:
           | ./onetime -d -n -p tests/random-data-1 -o -
 
 install:
-	@install -m755 onetime $(DESTDIR)/usr/bin/
+	@install -d -m 0755 $(bindir)
+	@install -m755 onetime $(bindir)
 
 uninstall:
-	@rm -v $(DESTDIR)/usr/bin/onetime
+	@rm -v $(prefix)/bin/onetime
 
 distclean: clean
 clean:


### PR DESCRIPTION
Closes #11.

My spam filter caught your reply for some reason, hence the extreme delay between reporting this and offering a PR to fix it. This commit allows people to specify the prefix in a more regular way though, and creates the bin directory if it doesn't exist to avoid people having to manually create that themselves where it doesn't already exist.

With this merged in you would install with ``` make prefix=/example/prefix install ``` and to remove you would do ``` make prefix=/example/prefix uninstall ```.